### PR TITLE
gallery: resolve NFC/NFD filename mismatches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/kradalby/kraweb v0.0.0-20241010194200-c56492e7e39c
+	golang.org/x/text v0.40.0
 )
 
 require (
@@ -61,7 +62,6 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	golang.zx2c4.com/wireguard/windows v1.0.1 // indirect

--- a/integration_test.go
+++ b/integration_test.go
@@ -630,3 +630,91 @@ func TestZipIsNotMountedWithoutAGallery(t *testing.T) {
 		t.Errorf("Content-Type = %q, so the probe would show a button", got)
 	}
 }
+
+// The half of the Munin contract that testdata cannot express: the gallery on
+// disk is inconsistent with the URLs Munin published into it.
+//
+// Munin names a keyword file after the IPTC keyword, whose Unicode
+// normalisation is whatever the app that wrote the photo chose, and it can
+// publish both spellings of one word while writing only one file. On the live
+// gallery that is 5 of 3,275 keyword URLs, in both directions. Munin's fix
+// cannot reach a directory generated years ago, so hugin resolves it: the exact
+// name wins, and only a miss retries the other canonical form.
+//
+// Written as escapes, not literal text: the two names render identically, and
+// an editor that normalises on save would otherwise silently gut these tests.
+const (
+	keywordNFD = "Nytt_a\u030Ar.json" // a + U+030A COMBINING RING ABOVE
+	keywordNFC = "Nytt_\u00E5r.json"  // U+00E5 LATIN SMALL LETTER A WITH RING
+)
+
+func TestKeywordStoredInTheOtherNormalizationStillServes(t *testing.T) {
+	for _, tc := range []struct{ label, onDisk, requested string }{
+		{label: "NFC on disk", onDisk: keywordNFC, requested: keywordNFD},
+		{label: "NFD on disk", onDisk: keywordNFD, requested: keywordNFC},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			dir := t.TempDir()
+
+			err := os.MkdirAll(filepath.Join(dir, "keywords"), 0o755)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = os.WriteFile(
+				filepath.Join(dir, "keywords", tc.onDisk), []byte(`{"name":"x"}`), 0o600)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			server := httptest.NewServer(routes(dir, ""))
+			defer server.Close()
+
+			resp := get(t, server.URL+"/content/keywords/"+tc.requested)
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("GET /content/keywords/%s = %d, want %d",
+					tc.requested, resp.StatusCode, http.StatusOK)
+			}
+		})
+	}
+}
+
+// A gallery holding both spellings holds two different collections. Falling
+// back on a hit would serve one under the other's name.
+func TestExactNameWinsOverItsOtherNormalization(t *testing.T) {
+	dir := t.TempDir()
+
+	err := os.MkdirAll(filepath.Join(dir, "keywords"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]string{keywordNFD: "decomposed", keywordNFC: "composed"}
+
+	for name, body := range want {
+		err = os.WriteFile(filepath.Join(dir, "keywords", name), []byte(body), 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	server := httptest.NewServer(routes(dir, ""))
+	defer server.Close()
+
+	for name, body := range want {
+		resp := get(t, server.URL+"/content/keywords/"+name)
+
+		got, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(got) != body {
+			t.Errorf("GET /content/keywords/%s served %q, want %q", name, got, body)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/kradalby/kraweb"
+	"golang.org/x/text/unicode/norm"
 )
 
 const defaultHostname = "hugin"
@@ -104,6 +105,57 @@ func distHandler() http.Handler {
 	return http.FileServer(http.FS(sub))
 }
 
+// Munin names keyword files after the IPTC keyword, which arrives in whichever
+// Unicode normalisation the app that wrote the photo used. The same word
+// reaches the gallery as both "Nytt_\u00e5r" and "Nytt_a\u030ar"; Munin
+// publishes both spellings as URLs but writes only one file. On the gallery
+// this was written against, 5 of 3,275 referenced keyword URLs name a file
+// that is not on disk, and every one of them has its counterpart form sitting
+// in the same directory.
+//
+// Gallery data outlives any Munin release — the fix upstream cannot reach a
+// directory generated years ago — so hugin resolves the mismatch itself.
+// Returns the other canonical form, or name unchanged when there isn't one
+// (which is every pure-ASCII path).
+func altNormalization(name string) string {
+	if composed := norm.NFC.String(name); composed != name {
+		return composed
+	}
+
+	return norm.NFD.String(name)
+}
+
+// A gallery directory that answers for either normalisation of a name.
+//
+// The exact name always wins, so a gallery holding both spellings still serves
+// each on its own name and nothing that works today changes. Only a miss falls
+// back, and only to the one other canonical form, so a request can never be
+// answered by a file it did not ask for. The fallback is logged: it means the
+// gallery is inconsistent, which is worth knowing rather than papering over.
+type normalizingDir string
+
+func (d normalizingDir) Open(name string) (http.File, error) {
+	f, err := http.Dir(d).Open(name)
+	if !errors.Is(err, fs.ErrNotExist) {
+		return f, err
+	}
+
+	alt := altNormalization(name)
+	if alt == name {
+		return f, err
+	}
+
+	altFile, altErr := http.Dir(d).Open(alt)
+	if altErr != nil {
+		// The original miss is the honest answer; the fallback was a guess.
+		return f, err
+	}
+
+	log.Printf("%q served as %q: gallery holds the other Unicode form", name, alt) //nolint:gosec
+
+	return altFile, nil
+}
+
 // http.FileServer swallows the os.Open error, so the status is all that
 // separates "missing" from "unreadable".
 type statusRecorder struct {
@@ -158,7 +210,7 @@ func routes(contentDir, rootDir string) *http.ServeMux {
 	mux.Handle("/tokens", tokenHandler())
 
 	serveDir := func(prefix, dir string) {
-		handler := loggingHandler(http.FileServer(http.Dir(dir)), dir)
+		handler := loggingHandler(http.FileServer(normalizingDir(dir)), dir)
 		mux.Handle(prefix+"/", http.StripPrefix(prefix, handler))
 	}
 

--- a/zip.go
+++ b/zip.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"math"
 	"mime"
@@ -244,8 +245,23 @@ func plan(dir, docPath string) (string, []member, error) {
 		return "", nil, err
 	}
 
-	// G304: confined by localize above.
+	// G304: confined by localize above, and altNormalization only ever swaps
+	// characters for their canonical equivalents — it cannot introduce a
+	// separator or a dot segment that localize did not already accept.
 	raw, err := os.ReadFile(filepath.Join(dir, local)) //nolint:gosec
+	if errors.Is(err, fs.ErrNotExist) {
+		// Same mismatch normalizingDir covers for /content/: Munin published a
+		// keyword URL in one Unicode normalisation and wrote the file in the
+		// other. Only a miss retries, so an exact hit is never second-guessed.
+		alt := altNormalization(local)
+		if alt != local {
+			altRaw, altErr := os.ReadFile(filepath.Join(dir, alt)) //nolint:gosec
+			if altErr == nil {
+				raw, err = altRaw, nil
+			}
+		}
+	}
+
 	if err != nil {
 		return "", nil, fmt.Errorf("reading collection %q: %w", docPath, err)
 	}

--- a/zip_test.go
+++ b/zip_test.go
@@ -792,3 +792,83 @@ func TestWriteZipRejectsAFileResizedAfterPlanning(t *testing.T) {
 		})
 	}
 }
+
+// Munin publishes a keyword URL in one Unicode normalisation and writes the
+// file in the other, so on a real gallery a handful of keyword collections name
+// a file that is not there. Both directions occur: of the five unreachable
+// keyword URLs on the live gallery, three asked for NFC and found NFD on disk,
+// two the reverse. Normalising the request one way would have fixed neither
+// set. keywordNFD/keywordNFC are in integration_test.go.
+func TestPlanFindsACollectionStoredInTheOtherNormalization(t *testing.T) {
+	doc := `{"name":"Nytt år","photos":[
+	  {"url":"root/Misc/a.json","originalImageURL":"root/Misc/a_original.jpg"}
+	]}`
+
+	for _, tc := range []struct{ label, onDisk, requested string }{
+		{label: "NFC on disk", onDisk: keywordNFC, requested: keywordNFD},
+		{label: "NFD on disk", onDisk: keywordNFD, requested: keywordNFC},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			dir := t.TempDir()
+			writeKeywordCollection(t, dir, tc.onDisk, doc)
+
+			name, members, err := plan(dir, "keywords/"+tc.requested)
+			if err != nil {
+				t.Fatalf("plan() error = %v, want the collection", err)
+			}
+
+			if want := "Nytt år.zip"; name != want || len(members) != 1 {
+				t.Fatalf("plan() = %q, %d members; want %q, 1", name, len(members), want)
+			}
+		})
+	}
+}
+
+// A gallery holding both spellings holds two different collections, and each
+// has to keep serving its own: an exact hit is never second-guessed.
+func TestPlanPrefersTheExactNameOverItsOtherNormalization(t *testing.T) {
+	dir := t.TempDir()
+
+	photo := `{"url":"root/Misc/a.json","originalImageURL":"root/Misc/a_original.jpg"}`
+	want := map[string]string{keywordNFD: "decomposed", keywordNFC: "composed"}
+
+	for name, label := range want {
+		writeKeywordCollection(t, dir, name, fmt.Sprintf(`{"name":%q,"photos":[%s]}`, label, photo))
+	}
+
+	for name, label := range want {
+		got, _, err := plan(dir, "keywords/"+name)
+		if err != nil {
+			t.Fatalf("plan(%q) error = %v", name, err)
+		}
+
+		if got != label+".zip" {
+			t.Errorf("plan(%q) = %q, want %q", name, got, label+".zip")
+		}
+	}
+}
+
+// A keyword collection plus the one original every fixture document points at.
+func writeKeywordCollection(t *testing.T, dir, name, doc string) {
+	t.Helper()
+
+	err := os.MkdirAll(filepath.Join(dir, "root/Misc"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(filepath.Join(dir, "root/Misc/a_original.jpg"), []byte("x"), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.MkdirAll(filepath.Join(dir, "keywords"), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(filepath.Join(dir, "keywords", name), []byte(doc), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Munin names keyword files after the IPTC string, whose Unicode normalisation is
whatever the app that wrote the photo chose. The same word reaches the gallery
as both `Nytt_år` and `Nytt_a` + combining ring, and Munin can publish one
spelling as a URL while writing the file under the other.

On the live gallery that is 5 of 3,275 referenced keyword URLs naming a file
that is not there — and every one has its counterpart form sitting in the same
directory. Direction is not fixed: 3 ask NFC and find NFD on disk, 2 the
reverse. So normalising requests one way fixes neither set, which is why this
is an `ENOENT` fallback rather than a normalisation pass.

Exact match always wins, so a gallery holding both spellings keeps serving each
under its own name and nothing that works today changes. Only a miss retries,
and only against the one other canonical form, so a request can never be
answered by a file it did not ask for. Canonical equivalence never introduces
or removes `/`, `\`, NUL or a dot segment, so this cannot widen what
`filepath.Localize` already accepted. The fallback logs when it fires: a
gallery that needs it is inconsistent, and that is worth seeing rather than
papering over.

Belongs here as well as upstream because gallery data on disk outlives any
Munin release — a directory generated years ago is never getting the ingest
fix. kradalby/munin#93 stops new galleries diverging; this serves the ones that
already have.

Note it deliberately does not rescue a *stale* file: if the wrongly-spelled
name exists, the exact match succeeds and the fallback never fires. That case
needs the file deleted, which munin#93's sweep does.

`golang.org/x/text` was already in `go.sum` via tailscale, so this promotes an
indirect dependency rather than adding one.

> Generated with the help of an AI assistant