### PR TITLE
nix: move off deprecated stdenv.is* and pkgs.system aliases

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -293,7 +293,7 @@
           '';
         }
         # NixOS module evaluation needs a Linux system.
-        // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+        // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
           module-eval = import ./module-eval.nix {
             inherit
               pkgs

--- a/module.nix
+++ b/module.nix
@@ -28,7 +28,7 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = self.packages.${pkgs.system}.default;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
       defaultText = lib.literalExpression "hugin flake package";
       description = "The hugin package to run.";
     };


### PR DESCRIPTION
`stdenv.isLinux` and `pkgs.system` are deprecated nixpkgs aliases. Both warn on eval and are slated for removal; move to `stdenv.hostPlatform.*` before they go.

Mechanical rename, no behaviour change. `nix flake check` and `nix build` pass.

> Generated with the help of an AI assistant